### PR TITLE
残り時間10秒未満でTNT保持者からタイマー表示を非表示にする機能

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -417,6 +417,12 @@ tnttag.bypass.cooldown  # クールダウン無視
 - YAML files (config.yml, arenas.yml, messages_ja_JP.yml, player stats) (001-tnt-tag-game)
 - Java 21, Kotlin 2.2.21 (混在プロジェクト) + Paper API 1.21.10-R0.1-SNAPSHOT (Minecraft server platform), Kotlin stdlib-jdk8 (003-auto-game-start)
 - YAML files (config.yml, arenas.yml, player stats) (003-auto-game-start)
+- Kotlin 2.2.21 / Java 21 + Paper API 1.21.10-R0.1-SNAPSHOT, kotlin-stdlib-jdk8 (004-tag-return-prevention)
+- YAML (config.yml, messages_ja_JP.yml) (004-tag-return-prevention)
+- Java 21 + Kotlin 2.2.21（混在プロジェクト、メイン実装はJava） + Paper API 1.21.10-R0.1-SNAPSHOT, Kotlin stdlib-jdk8 (005-tnt-holder-item)
+- YAML files (config.yml, player stats) (005-tnt-holder-item)
+- Java 21 + Paper API 1.21.5-R0.1-SNAPSHOT + Paper API (Bukkit BossBar API) (006-hide-bossbar-timer)
+- N/A（この機能はランタイムのみ） (006-hide-bossbar-timer)
 
 ## Recent Changes
 - 001-tnt-tag-game: Added Java 17 (for Minecraft 1.20.x compatibility)

--- a/src/main/java/com/example/tnttag/hud/ActionBarManager.java
+++ b/src/main/java/com/example/tnttag/hud/ActionBarManager.java
@@ -13,9 +13,18 @@ import org.bukkit.scheduler.BukkitTask;
 
 /**
  * Manages action bar display for players
+ *
+ * Updated: Hide remaining time from TNT holders when below threshold
+ * to prevent last-second tag strategies.
  */
 public class ActionBarManager {
-    
+
+    /**
+     * Threshold in seconds below which remaining time is hidden from TNT holders.
+     * This should match BossBarManager.BOSSBAR_HIDE_THRESHOLD.
+     */
+    private static final int TIME_HIDE_THRESHOLD = 10;
+
     private final TNTTagPlugin plugin;
     private BukkitTask updateTask;
     
@@ -87,23 +96,34 @@ public class ActionBarManager {
 
             if (round != null) {
                 int remainingTime = round.getRemainingTime();
+                boolean belowThreshold = remainingTime < TIME_HIDE_THRESHOLD;
 
                 if (!data.isAlive()) {
-                    // Spectating
-                    message = "§7観戦中 | §e生存者: " + game.getAlivePlayers().size() + "人";
+                    // Spectating - always show time (spectators can't influence the game)
+                    message = "§7観戦中 | §a残り: " + remainingTime + "秒 §7| §e生存者: " + game.getAlivePlayers().size() + "人";
 
                 } else if (data.isTNTHolder()) {
-                    // TNT holder
+                    // TNT holder - hide time when below threshold
                     if (remainingTime <= 3) {
-                        // Explosion countdown
+                        // Explosion countdown (final warning - always show)
                         message = "§4💥 爆発まで " + remainingTime + "... 💥";
+                    } else if (belowThreshold) {
+                        // Below threshold - hide exact time to prevent last-second strategies
+                        message = "§c⚠ TNTを持っています！急いでタッチ！⚠";
                     } else {
-                        message = "§c⚠ TNTを持っています！他の人にタッチ！⚠";
+                        // Above threshold - show time
+                        message = "§c⚠ TNTを持っています！残り: " + remainingTime + "秒 ⚠";
                     }
 
                 } else {
-                    // Normal player
-                    message = "§a残り時間: " + remainingTime + "秒 §7| §e生存者: " + game.getAlivePlayers().size() + "人";
+                    // Normal player (non-holder)
+                    if (belowThreshold) {
+                        // Below threshold - hide time so TNT holders can't ask others
+                        message = "§a逃げろ！ §7| §e生存者: " + game.getAlivePlayers().size() + "人";
+                    } else {
+                        // Above threshold - show time
+                        message = "§a残り時間: " + remainingTime + "秒 §7| §e生存者: " + game.getAlivePlayers().size() + "人";
+                    }
                 }
             }
         }

--- a/src/main/java/com/example/tnttag/hud/BossBarManager.java
+++ b/src/main/java/com/example/tnttag/hud/BossBarManager.java
@@ -5,6 +5,7 @@ import com.example.tnttag.game.GameInstance;
 import com.example.tnttag.game.Round;
 import com.example.tnttag.player.PlayerGameData;
 import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
 import org.bukkit.boss.BarColor;
 import org.bukkit.boss.BarStyle;
 import org.bukkit.boss.BossBar;
@@ -17,9 +18,19 @@ import java.util.UUID;
 
 /**
  * Manages boss bar display for TNT holders
+ *
+ * Updated: Hide boss bar from TNT holders when remaining time is below threshold
+ * to prevent last-second tag strategies and encourage active gameplay.
  */
 public class BossBarManager {
-    
+
+    /**
+     * Threshold in seconds below which boss bar is hidden from TNT holders.
+     * When remaining time is less than this value, TNT holders cannot see the timer,
+     * encouraging them to pass the TNT earlier rather than waiting until the last moment.
+     */
+    private static final int BOSSBAR_HIDE_THRESHOLD = 10;
+
     private final TNTTagPlugin plugin;
     private final Map<UUID, BossBar> playerBossBars;
     private BukkitTask updateTask;
@@ -54,23 +65,50 @@ public class BossBarManager {
     }
     
     /**
-     * Update all player boss bars
+     * Update all player boss bars based on remaining time and player state.
+     *
+     * When remaining time is at or above the threshold:
+     * - TNT holders see the boss bar (current behavior)
+     * - Non-holders do not see the boss bar
+     *
+     * When remaining time is below the threshold:
+     * - TNT holders do NOT see the boss bar (to prevent last-second strategies)
+     * - Non-holders (alive) see the boss bar (to know when explosion is near)
+     * - Spectators see the boss bar (for viewing experience)
      */
     public void updateAll() {
         for (GameInstance game : plugin.getGameManager().getAllGames()) {
             Round round = game.getActiveRound();
-            
+
             if (round == null) {
                 continue;
             }
-            
+
+            int remainingTime = round.getRemainingTime();
+            boolean belowThreshold = remainingTime < BOSSBAR_HIDE_THRESHOLD;
+
             for (Player player : game.getPlayers()) {
                 PlayerGameData data = plugin.getPlayerManager().getPlayerData(player);
-                
-                if (data.isTNTHolder() && data.isAlive()) {
-                    showBossBar(player, round);
+                boolean isTNTHolder = data.isTNTHolder();
+                boolean isAlive = data.isAlive();
+                boolean isSpectator = player.getGameMode() == GameMode.SPECTATOR;
+
+                if (belowThreshold) {
+                    // Below threshold: Hide from TNT holders, show to non-holders and spectators
+                    if (isTNTHolder && isAlive) {
+                        hideBossBar(player);
+                    } else if (isAlive || isSpectator) {
+                        showBossBar(player, round);
+                    } else {
+                        hideBossBar(player);
+                    }
                 } else {
-                    hideBossBar(player);
+                    // At or above threshold: Original behavior (TNT holders only)
+                    if (isTNTHolder && isAlive) {
+                        showBossBar(player, round);
+                    } else {
+                        hideBossBar(player);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- TNT保持者が終了間際まで待機してタッチする戦略を防ぐため、残り時間が10秒未満になるとタイマー表示を非表示にする
- ボスバーとアクションバーの両方で残り時間を隠す
- 非TNT保持者のアクションバーからも残り時間を隠す（他のプレイヤーに聞いて時間を知ることを防ぐ）

## 変更内容

### BossBarManager.java
- `BOSSBAR_HIDE_THRESHOLD`定数（10秒）を追加
- 残り時間が閾値未満のとき、TNT保持者のボスバーを非表示
- 非TNT保持者と観戦者には閾値未満でもボスバーを表示

### ActionBarManager.java
- `TIME_HIDE_THRESHOLD`定数（10秒）を追加
- TNT保持者: 閾値未満で「急いでタッチ！」（時間非表示）
- 非TNT保持者: 閾値未満で「逃げろ！」（時間非表示）
- 観戦者: 常に残り時間を表示
- TNT保持者に閾値以上では残り時間を表示するように改善

## Test plan
- [ ] TNT保持者として、残り時間が10秒以上のときにボスバーとアクションバーで時間が表示されることを確認
- [ ] TNT保持者として、残り時間が10秒未満になったときにボスバーが消え、アクションバーから時間表示が消えることを確認
- [ ] 非TNT保持者として、残り時間が10秒未満になったときにボスバーが表示され、アクションバーの時間表示が消えることを確認
- [ ] 観戦者として、残り時間が10秒未満でもボスバーとアクションバーで時間が表示されることを確認
- [ ] TNT受け渡し時に表示が即座に切り替わることを確認