### PR TITLE
ゲーム開始時に全プレイヤーを全回復する機能を実装

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -423,6 +423,7 @@ tnttag.bypass.cooldown  # クールダウン無視
 - YAML files (config.yml, player stats) (005-tnt-holder-item)
 - Java 21 + Paper API 1.21.5-R0.1-SNAPSHOT + Paper API (Bukkit BossBar API) (006-hide-bossbar-timer)
 - N/A（この機能はランタイムのみ） (006-hide-bossbar-timer)
+- N/A（この機能では永続化不要） (007-game-start-heal)
 
 ## Recent Changes
 - 001-tnt-tag-game: Added Java 17 (for Minecraft 1.20.x compatibility)

--- a/src/main/java/com/example/tnttag/game/GameInstance.java
+++ b/src/main/java/com/example/tnttag/game/GameInstance.java
@@ -10,7 +10,9 @@ import com.example.tnttag.stats.StatsManager;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
+import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.Player;
+import org.bukkit.potion.PotionEffect;
 import org.bukkit.scheduler.BukkitTask;
 
 import java.util.*;
@@ -270,6 +272,28 @@ public class GameInstance {
                 for (Player player : alivePlayers) {
                     player.teleport(arena.getCenterSpawn());
                 }
+            }
+
+            // Heal all players at game start (Round 1 only)
+            // This ensures fair conditions for all players regardless of pre-game damage
+            if (currentRound == 1) {
+                for (Player player : alivePlayers) {
+                    // US1: Health recovery - restore to max health
+                    player.setHealth(player.getAttribute(Attribute.MAX_HEALTH).getValue());
+
+                    // US2: Food and saturation recovery - restore to max
+                    player.setFoodLevel(20);
+                    player.setSaturation(20.0f);
+
+                    // US3: Clear all potion effects
+                    for (PotionEffect effect : player.getActivePotionEffects()) {
+                        player.removePotionEffect(effect.getType());
+                    }
+
+                    // US3: Extinguish fire
+                    player.setFireTicks(0);
+                }
+                plugin.getLogger().info("全プレイヤーを全回復しました");
             }
 
             // Apply effects


### PR DESCRIPTION
## Summary

- ゲーム開始時（ラウンド1開始時）に全プレイヤーを全回復する機能を追加
- ロビー待機中のフレンドリファイアによる不公平を解消

## 変更内容

| 項目 | 内容 |
|------|------|
| 体力回復 | 最大値まで回復 (`Attribute.MAX_HEALTH`使用) |
| 空腹度回復 | 最大値（20）まで回復 + saturation回復 |
| ステータス効果 | 全ポーション効果をクリア |
| 炎上状態 | 消火 (`setFireTicks(0)`) |

## 実装詳細

- `GameInstance.startRound()` メソッドに `currentRound == 1` チェックを追加
- テレポート後、エフェクト適用前に回復処理を実行
- 全プレイヤーに対して同時に回復を適用

## Test plan

- [ ] ダメージを受けた状態でゲームを開始し、体力が全回復することを確認
- [ ] 空腹状態でゲームを開始し、空腹度バーが満タンになることを確認
- [ ] 毒などのステータス効果を受けた状態でゲームを開始し、効果がクリアされることを確認
- [ ] 炎上中にゲームを開始し、消火されることを確認